### PR TITLE
support of favored nodes while compacting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dependency-reduced-pom.xml
 *.iml
 target/*
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-client</artifactId>
-            <version>1.0.3</version>
+            <version>2.1.9</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>hbase-compactor</groupId>
+    <groupId>com.flipkart.hbase</groupId>
     <artifactId>hbase-compactor</artifactId>
-    <version>1.0</version>
+    <version>2.0.0</version>
 
     <distributionManagement>
          <repository>

--- a/src/main/java/Compactor.java
+++ b/src/main/java/Compactor.java
@@ -1,15 +1,11 @@
 import config.CompactorConfig;
 import org.apache.commons.cli.MissingArgumentException;
-import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
-import org.apache.hadoop.hbase.exceptions.DeserializationException;
 import org.apache.log4j.Logger;
 import service.CompactionService;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 
 public class Compactor {
     private static Logger log = Logger.getLogger(Compactor.class);
@@ -19,9 +15,11 @@ public class Compactor {
             CompactorConfig compactorConfig = new CompactorConfig(args);
             Connection connection = ConnectionFactory.createConnection(compactorConfig.getHbaseConfig());
             new CompactionService(connection, compactorConfig).start();
-        } catch (IOException | InterruptedException  | MissingArgumentException e) {
+        } catch (MissingArgumentException e) {
             log.error(e);
-            e.printStackTrace();
+            System.exit(1);
+        } catch (IOException | InterruptedException e) {
+            log.error(e.getMessage(), e);
             System.exit(1);
         }
         System.exit(0);

--- a/src/main/java/config/CompactorConfig.java
+++ b/src/main/java/config/CompactorConfig.java
@@ -4,54 +4,49 @@ import org.apache.commons.cli.MissingArgumentException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.InvalidPropertiesFormatException;
 import java.util.Properties;
 
-
 public class CompactorConfig {
-    public static final int DEFAULT_BATCH_SIZE=1;
-    public static final int DEFAULT_WAIT=600;                           // seconds
+  public static final int DEFAULT_WAIT = 60;                           // seconds
+  public static final int RECOMPACT_REGION_HOURS = 6;                   // no recompaction within 6 hours
 
-    public static final String TABLE_NAME_KEY = "table_name";           // table name to compact
-    public static final String BATCH_SIZE_KEY = "batch_size";           // number of regions to compact concurrently
-    public static final String ZK_QUORUM_KEY = "zookeeper_quorum";      // zk quorum
-    public static final String ZK_NODE_KEY = "znode";                   // zk node
-    public static final String WAIT_TIME_KEY = "wait_time";             // sleep between each batch
+  public static final String TABLE_NAME_KEY = "table_name";           // table name to compact
+  public static final String BATCH_SIZE_KEY = "batch_size";           // number of regions to compact concurrently
+  public static final String ZK_QUORUM_KEY = "zookeeper_quorum";      // zk quorum
+  public static final String ZK_NODE_KEY = "znode";                   // zk node
+  public static final String WAIT_TIME_KEY = "wait_time";             // sleep between each batch
+  public static final String FORCE_COMPACTION = "force_compaction";   // force compaction if within recompaction gap
 
-    private Properties properties;
+  private Properties properties;
 
-    public CompactorConfig(String[] args) throws MissingArgumentException {
-        if(args.length < 4) {
-            throw new MissingArgumentException("Min args expected: <zk quorum> <zk node> <table name> <col family>");
-        }
-        properties = new Properties();
-        properties.put(ZK_QUORUM_KEY, args[0]);
-        properties.put(ZK_NODE_KEY, args[1]);
-        properties.put(TABLE_NAME_KEY, args[2]);
-
-        if(args.length > 3)
-            properties.put(BATCH_SIZE_KEY, Integer.valueOf(args[3]));
-        else
-            properties.put(BATCH_SIZE_KEY, DEFAULT_BATCH_SIZE);
-
-        if(args.length > 4)
-            properties.put(WAIT_TIME_KEY, Integer.valueOf(args[4]));
-        else
-            properties.put(WAIT_TIME_KEY, DEFAULT_WAIT);
+  public CompactorConfig(String[] args) throws MissingArgumentException {
+    if (args.length < 5) {
+      throw new MissingArgumentException(
+          "Usage: <zk_quorum> <zk_node> <table_name> [num_compactions] [delay] [force]\n\n"
+              + "zk_quorum: Zookeeper quorum. Example: preprod-id-yak-testbed-ch-zk-1,preprod-id-yak-testbed-ch-zk-2\n\n"
+              + "zk_node: Zookeeper znode. Example: /hbase\n\n" + "table_name: Table name to compact\n\n"
+              + "num_compactions: number of region compactions in parallel.\n\n"
+              + "delay: Delay between 2 compaction triggers. Default: 600 seconds\n\n"
+              + "force: region compacted in last 3 hours will be ignored unless this flag is passed. Optional: true\n");
     }
+    properties = new Properties();
+    properties.put(ZK_QUORUM_KEY, args[0]);
+    properties.put(ZK_NODE_KEY, args[1]);
+    properties.put(TABLE_NAME_KEY, args[2]);
+    properties.put(BATCH_SIZE_KEY, Integer.valueOf(args[3]));
+    properties.put(WAIT_TIME_KEY, Integer.valueOf(args[4]) < 300 ? DEFAULT_WAIT : Integer.valueOf(args[4]));
+    properties.put(FORCE_COMPACTION, (args.length > 5 && args[5].equals("force")) ? true : false);
+  }
 
-    public Object getConfig(String key) {
-        return properties.get(key);
-    }
+  public Object getConfig(String key) {
+    return properties.get(key);
+  }
 
-    public Configuration getHbaseConfig() {
-        Configuration configuration = HBaseConfiguration.create();
-        configuration.clear();
-        configuration.set("hbase.zookeeper.quorum", (String) getConfig(ZK_QUORUM_KEY));
-        configuration.set("zookeeper.znode.parent", (String) getConfig(ZK_NODE_KEY));
-        return configuration;
-    }
+  public Configuration getHbaseConfig() {
+    Configuration configuration = HBaseConfiguration.create();
+    configuration.clear();
+    configuration.set("hbase.zookeeper.quorum", (String) getConfig(ZK_QUORUM_KEY));
+    configuration.set("zookeeper.znode.parent", (String) getConfig(ZK_NODE_KEY));
+    return configuration;
+  }
 }

--- a/src/main/java/service/RegionFetcher.java
+++ b/src/main/java/service/RegionFetcher.java
@@ -78,7 +78,11 @@ public class RegionFetcher {
           List<String> fnHostsList = getFavoredNodesList(result.getValue(INFO_CF, FN_CQ));
           String[] tokens = Bytes.toString(result.getRow()).split("\\.");
           log.trace("Identified Region: " + tokens[tokens.length - 1] + " fns: " + fnHostsList);
-          regionFNHostnameMapping.put(tokens[tokens.length - 1], fnHostsList);
+          if (fnHostsList.size() > 0) {
+            regionFNHostnameMapping.put(tokens[tokens.length - 1], fnHostsList);
+          } else {
+            regionFNHostnameMapping.putIfAbsent(tokens[tokens.length - 1], fnHostsList);
+          }
         }
       } else {
         break;
@@ -95,9 +99,9 @@ public class RegionFetcher {
       List<RegionInfo> regions = this.admin.getRegions(sn);
       regions.stream().forEach(region -> {
         if (allRegions.contains(region.getEncodedName())) {
-          regionFNHostnameMapping.putIfAbsent(region.getEncodedName(), new ArrayList<String>() {{
-            sn.getHostname();
-          }});
+          ArrayList<String> temp = new ArrayList<String>();
+          temp.add(sn.getHostname());
+          regionFNHostnameMapping.putIfAbsent(region.getEncodedName(), temp);
         }
       });
     }


### PR DESCRIPTION
Major compaction takes up additional disk space, in that view just keeping at most one compaction per regionserver isn't sufficient, but also need to consider favorednodes as well. Along with that, upgraded the client for 2.1.x version and simplified the logic.